### PR TITLE
Re-organized the details section of the Me page

### DIFF
--- a/Pupil/Core/StudentView/DoctorsView.swift
+++ b/Pupil/Core/StudentView/DoctorsView.swift
@@ -12,22 +12,85 @@ struct DoctorsView: View {
     let info: StudentInfo
     var body: some View {
         if !info.physician.name.isEmpty {
-            StudentInfoRowView(image: "facemask.fill", color: .blue, name: String(localized: "DOCTORS_PHYSICAIN_LABEL", defaultValue: "Physician", comment: "Physician label for the doctors page"), value: info.physician.name)
+            DisclosureGroup {
+                LabeledContent(
+                    String(
+                        localized: "PHYSICIAN_HOSPITAL_NAME",
+                        defaultValue: "\(info.physician.hospital)",
+                        comment: "The physician's hospital name"
+                    ),
+                    value: String(
+                        localized: "PHYSICIAN_PHONE_NUMBER",
+                        defaultValue: "\(info.physician.phone)\(info.physician.extn.count != 0 ? info.physician.extn : "")",
+                        comment: "The phone number for the physician"
+                    )
+                )
                 .contextMenu {
-                    Text(info.physician.hospital)
                     if let url = URL(string: "tel:\(info.physician.phone)\(info.physician.extn.count != 0 ? info.physician.extn : "")") {
-                        Link("\(info.physician.phone)\(info.physician.extn.count != 0 ? info.physician.extn : "")", destination: url)
+                        Link(
+                            String(
+                                localized: "PHYSICIAN_CALL_PHONE",
+                                defaultValue: "Call",
+                                comment: "Call the physician's phone number"
+                            ),
+                            destination: url
+                        )
                     }
+                    
                 }
+            } label: {
+                StudentInfoRowView(
+                    image: "facemask.fill",
+                    color: .blue,
+                    name: String(
+                        localized: "DOCTORS_PHYSICIAN_LABEL",
+                        defaultValue: "Physician",
+                        comment: "Physician label for the doctors page"
+                    ),
+                    value: info.physician.name
+                )
+            }
         }
+        
         if !info.dentist.name.isEmpty {
-            StudentInfoRowView(image: "facemask.fill", color: .blue, name: String(localized: "DOCTORS_DENTIST_LABEL", defaultValue: "Dentist", comment: "Dentist label for the doctors page"), value: info.dentist.name)
+            DisclosureGroup {
+                LabeledContent(
+                    String(
+                        localized: "DENTIST_OFFICE_NAME",
+                        defaultValue: "\(info.dentist.office)",
+                        comment: "The dentist's office name"
+                    ),
+                    value: String(
+                        localized: "DENTIST_PHONE_NUMBER",
+                        defaultValue: "\(info.dentist.phone)\(info.dentist.extn.count != 0 ? info.dentist.extn : "")",
+                        comment: "The phone number for the dentist"
+                    )
+                )
                 .contextMenu {
-                    Text(info.dentist.office)
                     if let url = URL(string: "tel:\(info.dentist.phone)\(info.dentist.extn.count != 0 ? info.dentist.extn : "")") {
-                        Link("\(info.dentist.phone)\(info.dentist.extn.count != 0 ? info.dentist.extn : "")", destination: url)
+                        Link(
+                            String(
+                                localized: "DENTIST_CALL_PHONE",
+                                defaultValue: "Call",
+                                comment: "Call the dentist's phone number"
+                            ),
+                            destination: url
+                        )
                     }
+                    
                 }
+            } label: {
+                StudentInfoRowView(
+                    image: "facemask.fill",
+                    color: .blue,
+                    name: String(
+                        localized: "DOCTORS_DENTIST_LABEL",
+                        defaultValue: "Dentist",
+                        comment: "Dentist label for the doctors page"
+                    ),
+                    value: info.dentist.name
+                )
+            }
         }
     }
 }

--- a/Pupil/Core/StudentView/EmergencyContactsView.swift
+++ b/Pupil/Core/StudentView/EmergencyContactsView.swift
@@ -12,21 +12,111 @@ struct EmergencyContactsView: View {
     let info: StudentInfo
     var body: some View {
         ForEach(info.emergencyContacts) { contact in
-            StudentInfoRowView(image: "person.fill", color: .red, name: contact.relationship, value: contact.name)
-                .contextMenu {
-                    if !contact.homePhone.isEmpty, let url = URL(string: "tel:\(contact.homePhone)") {
-                        Link(String(localized: "EMERGENCY_CONTACT_HOME_PHONE", defaultValue: "\(contact.homePhone) - Home", comment: "The home phone number for the emergency contact"), destination: url)
-                    }
-                    if !contact.workPhone.isEmpty, let url = URL(string: "tel:\(contact.workPhone)") {
-                        Link(String(localized: "EMERGENCY_CONTACT_WORK_PHONE", defaultValue: "\(contact.workPhone) - Work", comment: "The work phone number for the emergency contact"), destination: url)
-                    }
-                    if !contact.otherPhone.isEmpty, let url = URL(string: "tel:\(contact.otherPhone)") {
-                        Link(String(localized: "EMERGENCY_CONTACT_OTHER_PHONE", defaultValue: "\(contact.otherPhone) - Other", comment: "The other phone number for the emergency contact"), destination: url)
-                    }
-                    if !contact.mobilePhone.isEmpty, let url = URL(string: "tel:\(contact.mobilePhone)") {
-                        Link(String(localized: "EMERGENCY_CONTACT_MOBILE_PHONE", defaultValue: "\(contact.mobilePhone) - Mobile", comment: "The mobile phone number for the emergency contact"), destination: url)
+            DisclosureGroup {
+                if !contact.homePhone.isEmpty, let url = URL(string: "tel:\(contact.homePhone)") {
+                    LabeledContent(
+                        String(
+                            localized: "EMERGENCY_CONTACT_HOME_PHONE_LABEL",
+                            defaultValue: "Home",
+                            comment: "The home phone label"
+                        ),
+                        value: String(
+                            localized: "EMERGENCY_CONTACT_HOME_PHONE",
+                            defaultValue: "\(contact.homePhone)",
+                            comment: "The home phone number for the emergency contact"
+                        )
+                    )
+                    .contextMenu {
+                        Link(
+                            String(
+                                localized: "EMERGENCY_CONTACT_CALL_HOME_PHONE",
+                                defaultValue: "Call",
+                                comment: "Call the home phone number"
+                            ),
+                            destination: url
+                        )
                     }
                 }
+                if !contact.workPhone.isEmpty, let url = URL(string: "tel:\(contact.workPhone)") {
+                    LabeledContent(
+                        String(
+                            localized: "EMERGENCY_CONTACT_WORK_PHONE_LABEL",
+                            defaultValue: "Work",
+                            comment: "The work phone label"
+                        ),
+                        value: String(
+                            localized: "EMERGENCY_CONTACT_WORK_PHONE",
+                            defaultValue: "\(contact.workPhone)",
+                            comment: "The work phone number for the emergency contact"
+                        )
+                    )
+                    .contextMenu {
+                        Link(
+                            String(
+                                localized: "EMERGENCY_CONTACT_CALL_WORK_PHONE",
+                                defaultValue: "Call",
+                                comment: "Call the work phone number"
+                            ),
+                            destination: url
+                        )
+                    }
+                }
+                if !contact.otherPhone.isEmpty, let url = URL(string: "tel:\(contact.otherPhone)") {
+                    LabeledContent(
+                        String(
+                            localized: "EMERGENCY_CONTACT_OTHER_PHONE_LABEL",
+                            defaultValue: "Other",
+                            comment: "The other phone label"
+                        ),
+                        value: String(
+                            localized: "EMERGENCY_CONTACT_OTHER_PHONE",
+                            defaultValue: "\(contact.otherPhone)",
+                            comment: "The other phone number for the emergency contact"
+                        )
+                    )
+                    .contextMenu {
+                        Link(
+                            String(
+                                localized: "EMERGENCY_CONTACT_CALL_OTHER_PHONE",
+                                defaultValue: "Call",
+                                comment: "Call the other phone number"
+                            ),
+                            destination: url
+                        )
+                    }
+                }
+                if !contact.mobilePhone.isEmpty, let url = URL(string: "tel:\(contact.mobilePhone)") {
+                    LabeledContent(
+                        String(
+                            localized: "EMERGENCY_CONTACT_MOBILE_PHONE_LABEL",
+                            defaultValue: "Mobile",
+                            comment: "The mobile phone label"
+                        ),
+                        value: String(
+                            localized: "EMERGENCY_CONTACT_MOBILE_PHONE",
+                            defaultValue: "\(contact.mobilePhone)",
+                            comment: "The mobile phone number for the emergency contact"
+                        )
+                    )
+                    .contextMenu {
+                        Link(
+                            String(
+                                localized: "EMERGENCY_CONTACT_CALL_MOBILE_PHONE",
+                                defaultValue: "Call",
+                                comment: "Call the mobile phone number"
+                            ),
+                            destination: url
+                        )
+                    }
+                }
+            } label: {
+                StudentInfoRowView(
+                    image: "staroflife.fill",
+                    color: .red,
+                    name: contact.relationship,
+                    value: contact.name
+                )
+            }
         }
     }
 }

--- a/Pupil/Core/StudentView/IDCardRowView.swift
+++ b/Pupil/Core/StudentView/IDCardRowView.swift
@@ -26,8 +26,14 @@ struct IDCardRowView: View {
             VStack (alignment: .leading) {
                 Text(info.formattedName)
                     .font(.title2)
-                Text(String(localized: "ID_CARD_ROW_SUBTITLE", defaultValue: "View ID Card", comment: "Subtitle for the id card row in settings"))
-                    .font(.footnote)
+                Text(
+                    String(
+                        localized: "ID_CARD_ROW_SUBTITLE",
+                        defaultValue: "View ID Card",
+                        comment: "Subtitle for the id card row in settings"
+                    )
+                )
+                .font(.footnote)
             }
         }
     }

--- a/Pupil/Core/StudentView/IDCardView.swift
+++ b/Pupil/Core/StudentView/IDCardView.swift
@@ -49,7 +49,13 @@ struct IDCardView: View {
                     Text(info.formattedName)
                         .font(.title)
                         .fontWeight(.semibold)
-                    Text(String(localized: "ID_CARD_USER_GRADE", defaultValue: "Grade \(info.grade)", comment: "The current grade of the user"))
+                    Text(
+                        String(
+                            localized: "ID_CARD_USER_GRADE",
+                            defaultValue: "Grade \(info.grade)",
+                            comment: "The current grade of the user"
+                        )
+                    )
                 }
                 Spacer()
             }
@@ -60,11 +66,27 @@ struct IDCardView: View {
                 .frame(height: 8)
                 .foregroundColor(accentColor)
             
-            Picker(String(localized: "ID_CARD_TYPE_PICKER_TITLE", defaultValue: "ID type", comment: "Picker title for the ID card type (barcode or qr code)"), selection: $usingBarCode.animation(.spring)) {
-                Text(String(localized: "ID_CARD_BAR_CODE_TYPE", defaultValue: "Bar code", comment: "The bar code type of id card display"))
-                    .tag(true)
-                Text(String(localized: "ID_CARD_QR_CODE_TYPE", defaultValue: "QR code", comment: "The qr code type of id card display"))
-                    .tag(false)
+            Picker(String(
+                localized: "ID_CARD_TYPE_PICKER_TITLE",
+                defaultValue: "ID type",
+                comment: "Picker title for the ID card type (barcode or qr code)"
+            ), selection: $usingBarCode.animation(.spring)) {
+                Text(
+                    String(
+                        localized: "ID_CARD_BAR_CODE_TYPE",
+                        defaultValue: "Bar code",
+                        comment: "The bar code type of id card display"
+                    )
+                )
+                .tag(true)
+                Text(
+                    String(
+                        localized: "ID_CARD_QR_CODE_TYPE",
+                        defaultValue: "QR code",
+                        comment: "The qr code type of id card display"
+                    )
+                )
+                .tag(false)
             }
             .pickerStyle(.segmented)
             .padding(.horizontal)
@@ -100,8 +122,16 @@ struct IDCardView: View {
         .frame(maxWidth: 450)
         .safeAreaInset(edge: .bottom) {
             if let customIDPhoto, let _ = UIImage(data: customIDPhoto) {
-                let showOriginalPhotoText = String(localized: "ID_CARD_SHOW_ORIGINAL_PHOTO_BUTTON", defaultValue: "Show original photo", comment: "Button to show the original id card photo")
-                let showCustomPhotoText = String(localized: "ID_CARD_SHOW_CUSTOM_PHOTO_BUTTON", defaultValue: "Show custom photo", comment: "Button to show the custom id card photo")
+                let showOriginalPhotoText = String(
+                    localized: "ID_CARD_SHOW_ORIGINAL_PHOTO_BUTTON",
+                    defaultValue: "Show original photo",
+                    comment: "Button to show the original id card photo"
+                )
+                let showCustomPhotoText = String(
+                    localized: "ID_CARD_SHOW_CUSTOM_PHOTO_BUTTON",
+                    defaultValue: "Show custom photo",
+                    comment: "Button to show the custom id card photo"
+                )
                 Button(showingCustomPhoto ? showOriginalPhotoText : showCustomPhotoText) {
                     showingCustomPhoto.toggle()
                 }

--- a/Pupil/Core/StudentView/OtherInfoView.swift
+++ b/Pupil/Core/StudentView/OtherInfoView.swift
@@ -11,12 +11,13 @@ import SwiftVue
 struct OtherInfoView: View {
     let info: StudentInfo
     var body: some View {
-        ForEach(info.userDefinedGroupBoxes) { box in
-            Section {
-                ForEach(box.userDefinedItems) { item in
-                    StudentInfoRowView(image: "person.fill", color: .orange, name: item.itemLabel, value: item.value)
-                }
-            }
+        ForEach(info.userDefinedGroupBoxes.flatMap(\.userDefinedItems)) { item in
+            StudentInfoRowView(
+                image: "tag.fill",
+                color: .orange,
+                name: item.itemLabel,
+                value: item.value
+            )
         }
     }
 }

--- a/Pupil/Core/StudentView/StudentInfoRowView.swift
+++ b/Pupil/Core/StudentView/StudentInfoRowView.swift
@@ -33,5 +33,10 @@ struct StudentInfoRowView: View {
 }
 
 #Preview("StudentInfoRowView") {
-    StudentInfoRowView(image: "facemask.fill", color: .blue, name: "Dentist", value: "Ashlee Aragon")
+    StudentInfoRowView(
+        image: "facemask.fill",
+        color: .blue,
+        name: "Dentist",
+        value: "Ashlee Aragon"
+    )
 }

--- a/Pupil/Core/StudentView/StudentView.swift
+++ b/Pupil/Core/StudentView/StudentView.swift
@@ -14,6 +14,12 @@ struct StudentView: View {
     var body: some View {
         NavigationStack {
             List {
+                if let error = vm.error {
+                    Text(error.localizedDescription)
+                        .font(.headline)
+                        .foregroundColor(.red)
+                }
+                
                 if let studentInfo = vm.studentInfo {
                     Section {
                         NavigationLink {
@@ -23,62 +29,148 @@ struct StudentView: View {
                         }
                     }
                     
-                    Section(String(localized: "STUDENT_INFO_SECTION_HEADER_BASICS", defaultValue: "Basics", comment: "The section header for basics in the student info page")) {
+                    Section(
+                        String(
+                            localized: "STUDENT_INFO_SECTION_HEADER_BASICS",
+                            defaultValue: "Basics",
+                            comment: "The section header for basics in the student info page"
+                        )
+                    ) {
                         if !studentInfo.gender.isEmpty {
-                            StudentInfoRowView(image: "person.fill", color: .orange, name: String(localized: "STUDENT_INFO_GENDER_LABEL", defaultValue: "Gender", comment: "Label for student gender"), value: studentInfo.gender)
+                            StudentInfoRowView(
+                                image: "person.fill",
+                                color: .orange,
+                                name: String(
+                                    localized: "STUDENT_INFO_GENDER_LABEL",
+                                    defaultValue: "Gender",
+                                    comment: "Label for student gender"
+                                ),
+                                value: studentInfo.gender
+                            )
                         }
                         if !studentInfo.grade.isEmpty {
-                            StudentInfoRowView(image: "graduationcap.fill", color: .green, name: String(localized: "STUDENT_INFO_GRADE_LABEL", defaultValue: "Grade", comment: "Label for student grade"), value: studentInfo.grade)
+                            StudentInfoRowView(
+                                image: "graduationcap.fill",
+                                color: .green,
+                                name: String(
+                                    localized: "STUDENT_INFO_GRADE_LABEL",
+                                    defaultValue: "Grade",
+                                    comment: "Label for student grade"
+                                ),
+                                value: studentInfo.grade
+                            )
                         }
                         if !studentInfo.birthDate.isEmpty {
-                            StudentInfoRowView(image: "calendar", color: .red, name: String(localized: "STUDENT_INFO_BIRTH_LABEL", defaultValue: "Birth Date", comment: "Label for student birth date"), value: studentInfo.birthDate)
+                            StudentInfoRowView(
+                                image: "calendar",
+                                color: .red,
+                                name: String(
+                                    localized: "STUDENT_INFO_BIRTH_LABEL",
+                                    defaultValue: "Birth Date",
+                                    comment: "Label for student birth date"
+                                ),
+                                value: studentInfo.birthDate
+                            )
                         }
                         if !studentInfo.address.isEmpty {
-                            StudentInfoRowView(image: "house.fill", color: .blue, name: String(localized: "STUDENT_INFO_ADDRESS_LABEL", defaultValue: "Address", comment: "Label for student address"), value: studentInfo.address)
+                            StudentInfoRowView(
+                                image: "house.fill",
+                                color: .blue,
+                                name: String(
+                                    localized: "STUDENT_INFO_ADDRESS_LABEL",
+                                    defaultValue: "Address",
+                                    comment: "Label for student address"
+                                ),
+                                value: studentInfo.address
+                            )
                         }
                         if !studentInfo.email.isEmpty {
-                            StudentInfoRowView(image: "envelope.fill", color: .blue, name: String(localized: "STUDENT_INFO_EMAIL_LABEL", defaultValue: "Email", comment: "Label for student email"), value: studentInfo.email.lowercased())
-                                .contextMenu {
-                                    if let url = URL(string: "mailto:\(studentInfo.email)") {
-                                        Link(String(localized: "EMAIL_BUTTON", defaultValue: "Email", comment: "Button to email"), destination: url)
-                                    } else {
-                                        Text("\(studentInfo.email)")
-                                    }
+                            StudentInfoRowView(
+                                image: "envelope.fill",
+                                color: .blue,
+                                name: String(
+                                    localized: "STUDENT_INFO_EMAIL_LABEL",
+                                    defaultValue: "Email",
+                                    comment: "Label for student email"
+                                ),
+                                value: studentInfo.email.lowercased()
+                            )
+                            .contextMenu {
+                                if let url = URL(string: "mailto:\(studentInfo.email)") {
+                                    Link(
+                                        String(
+                                            localized: "EMAIL_BUTTON",
+                                            defaultValue: "Email",
+                                            comment: "Button to email"
+                                        ),
+                                        destination: url
+                                    )
+                                } else {
+                                    Text("\(studentInfo.email)")
                                 }
+                            }
                         }
                         if !studentInfo.phone.isEmpty {
-                            StudentInfoRowView(image: "phone.fill", color: .green, name: String(localized: "STUDENT_INFO_PHONE_LABEL", defaultValue: "Phone", comment: "Label for student phone number"), value: studentInfo.phone)
-                                .contextMenu {
-                                    if let url = URL(string: "tel:\(studentInfo.phone)") {
-                                        Link(String(localized: "CALL_BUTTON", defaultValue: "Call", comment: "Button to call"), destination: url)
-                                    } else {
-                                        Text("\(studentInfo.phone)")
-                                    }
+                            StudentInfoRowView(
+                                image: "phone.fill",
+                                color: .green,
+                                name: String(
+                                    localized: "STUDENT_INFO_PHONE_LABEL",
+                                    defaultValue: "Phone",
+                                    comment: "Label for student phone number"
+                                ),
+                                value: studentInfo.phone
+                            )
+                            .contextMenu {
+                                if let url = URL(string: "tel:\(studentInfo.phone)") {
+                                    Link(
+                                        String(
+                                            localized: "CALL_BUTTON",
+                                            defaultValue: "Call",
+                                            comment: "Button to call"
+                                        ),
+                                        destination: url
+                                    )
+                                } else {
+                                    Text("\(studentInfo.phone)")
                                 }
+                            }
                         }
                     }
                     
-                    Section(String(localized: "STUDENT_INFO_SECTION_HEADER_DETAILS", defaultValue: "Details", comment: "The section header fot details in the student info page")) {
-                        if !studentInfo.emergencyContacts.isEmpty {
-                            DisclosureGroup {
-                                EmergencyContactsView(info: studentInfo)
-                            } label: {
-                                StudentInfoRowView(image: "exclamationmark.shield.fill", color: .red, name: String(localized: "STUDENT_INFO_EMERGENCY_CONTACTS_LABEL", defaultValue: "Emergency Contacts", comment: "Label for the emergency contacts disclosure group"))
-                            }
+                    if !studentInfo.emergencyContacts.isEmpty {
+                        Section(
+                            String(
+                                localized: "STUDENT_INFO_SECTION_HEADER_EMERGENCY_CONTACTS",
+                                defaultValue: "Emergency Contacts",
+                                comment: "The section header for emergency contacts in the student info page"
+                            )
+                        ) {
+                            EmergencyContactsView(info: studentInfo)
                         }
-                        if !studentInfo.dentist.name.isEmpty || !studentInfo.physician.name.isEmpty {
-                            DisclosureGroup {
-                                DoctorsView(info: studentInfo)
-                            } label: {
-                                StudentInfoRowView(image: "staroflife.fill", color: .blue, name: String(localized: "STUDENT_INFO_DOCTORS_LABEL", defaultValue: "Doctors", comment: "Label for the doctors disclosure group"))
-                            }
+                    }
+                    
+                    if !studentInfo.dentist.name.isEmpty || !studentInfo.physician.name.isEmpty {
+                        Section(
+                            String(
+                                localized: "STUDENT_INFO_SECTION_HEADER_DOCTORS",
+                                defaultValue: "Doctors",
+                                comment: "The section header for doctors in the student info page"
+                            )
+                        ) {
+                            DoctorsView(info: studentInfo)
                         }
-                        if !studentInfo.userDefinedGroupBoxes.isEmpty {
-                            DisclosureGroup {
-                                OtherInfoView(info: studentInfo)
-                            } label: {
-                                StudentInfoRowView(image: "person.crop.circle.badge.fill", color: .orange, name: String(localized: "STUDENT_INFO_OTHER_LABEL", defaultValue: "Other", comment: "Label for the other disclosure group"))
-                            }
+                    }
+                    
+                    if !studentInfo.userDefinedGroupBoxes.isEmpty {
+                        Section(
+                            String(
+                                localized: "STUDENT_INFO_SECTION_HEADER_OTHER",
+                                defaultValue: "Other",
+                                comment: "The section header for other information in the student info page"
+                            )
+                        ) {
+                            OtherInfoView(info: studentInfo)
                         }
                     }
                 }
@@ -93,10 +185,21 @@ struct StudentView: View {
             .refreshable {
                 await vm.refresh()
             }
-            .navigationTitle(String(localized: "STUDENT_INFO_NAV_TITLE", defaultValue: "Me", comment: "Navigation title for the student info page"))
+            .navigationTitle(
+                String(
+                    localized: "STUDENT_INFO_NAV_TITLE",
+                    defaultValue: "Me",
+                    comment: "Navigation title for the student info page"
+                )
+            )
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
-                    Button(String(localized: "LOG_OUT_BUTTON_TEXT", defaultValue: "Log Out")) {
+                    Button(
+                        String(
+                            localized: "LOG_OUT_BUTTON_TEXT",
+                            defaultValue: "Log Out"
+                        )
+                    ) {
                         logout()
                     }
                     .tint(.red)

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -4,16 +4,6 @@
     "%@" : {
 
     },
-    "%@%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@"
-          }
-        }
-      }
-    },
     "%lld" : {
 
     },
@@ -653,6 +643,42 @@
         }
       }
     },
+    "DENTIST_CALL_PHONE" : {
+      "comment" : "Call the dentist's phone number",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call"
+          }
+        }
+      }
+    },
+    "DENTIST_OFFICE_NAME" : {
+      "comment" : "The dentist's office name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        }
+      }
+    },
+    "DENTIST_PHONE_NUMBER" : {
+      "comment" : "The phone number for the dentist",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@"
+          }
+        }
+      }
+    },
     "DISTRICT_FINDER_ZIP" : {
       "comment" : "The zip code field",
       "extractionState" : "extracted_with_value",
@@ -677,7 +703,7 @@
         }
       }
     },
-    "DOCTORS_PHYSICAIN_LABEL" : {
+    "DOCTORS_PHYSICIAN_LABEL" : {
       "comment" : "Physician label for the doctors page",
       "extractionState" : "extracted_with_value",
       "localizations" : {
@@ -737,6 +763,54 @@
         }
       }
     },
+    "EMERGENCY_CONTACT_CALL_HOME_PHONE" : {
+      "comment" : "Call the home phone number",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_CALL_MOBILE_PHONE" : {
+      "comment" : "Call the mobile phone number",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_CALL_OTHER_PHONE" : {
+      "comment" : "Call the other phone number",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_CALL_WORK_PHONE" : {
+      "comment" : "Call the work phone number",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call"
+          }
+        }
+      }
+    },
     "EMERGENCY_CONTACT_HOME_PHONE" : {
       "comment" : "The home phone number for the emergency contact",
       "extractionState" : "extracted_with_value",
@@ -744,7 +818,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%@ - Home"
+            "value" : "%@"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_HOME_PHONE_LABEL" : {
+      "comment" : "The home phone label",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Home"
           }
         }
       }
@@ -756,7 +842,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%@ - Mobile"
+            "value" : "%@"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_MOBILE_PHONE_LABEL" : {
+      "comment" : "The mobile phone label",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Mobile"
           }
         }
       }
@@ -768,7 +866,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%@ - Other"
+            "value" : "%@"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_OTHER_PHONE_LABEL" : {
+      "comment" : "The other phone label",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Other"
           }
         }
       }
@@ -780,7 +890,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%@ - Work"
+            "value" : "%@"
+          }
+        }
+      }
+    },
+    "EMERGENCY_CONTACT_WORK_PHONE_LABEL" : {
+      "comment" : "The work phone label",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Work"
           }
         }
       }
@@ -1265,6 +1387,42 @@
         }
       }
     },
+    "PHYSICIAN_CALL_PHONE" : {
+      "comment" : "Call the physician's phone number",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Call"
+          }
+        }
+      }
+    },
+    "PHYSICIAN_HOSPITAL_NAME" : {
+      "comment" : "The physician's hospital name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@"
+          }
+        }
+      }
+    },
+    "PHYSICIAN_PHONE_NUMBER" : {
+      "comment" : "The phone number for the physician",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@"
+          }
+        }
+      }
+    },
     "PINK" : {
       "comment" : "Name for pink",
       "extractionState" : "extracted_with_value",
@@ -1709,18 +1867,6 @@
         }
       }
     },
-    "STUDENT_INFO_DOCTORS_LABEL" : {
-      "comment" : "Label for the doctors disclosure group",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Doctors"
-          }
-        }
-      }
-    },
     "STUDENT_INFO_EMAIL_LABEL" : {
       "comment" : "Label for student email",
       "extractionState" : "extracted_with_value",
@@ -1729,18 +1875,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Email"
-          }
-        }
-      }
-    },
-    "STUDENT_INFO_EMERGENCY_CONTACTS_LABEL" : {
-      "comment" : "Label for the emergency contacts disclosure group",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Emergency Contacts"
           }
         }
       }
@@ -1781,18 +1915,6 @@
         }
       }
     },
-    "STUDENT_INFO_OTHER_LABEL" : {
-      "comment" : "Label for the other disclosure group",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Other"
-          }
-        }
-      }
-    },
     "STUDENT_INFO_PHONE_LABEL" : {
       "comment" : "Label for student phone number",
       "extractionState" : "extracted_with_value",
@@ -1817,14 +1939,38 @@
         }
       }
     },
-    "STUDENT_INFO_SECTION_HEADER_DETAILS" : {
-      "comment" : "The section header fot details in the student info page",
+    "STUDENT_INFO_SECTION_HEADER_DOCTORS" : {
+      "comment" : "The section header for doctors in the student info page",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Details"
+            "value" : "Doctors"
+          }
+        }
+      }
+    },
+    "STUDENT_INFO_SECTION_HEADER_EMERGENCY_CONTACTS" : {
+      "comment" : "The section header for emergency contacts in the student info page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Emergency Contacts"
+          }
+        }
+      }
+    },
+    "STUDENT_INFO_SECTION_HEADER_OTHER" : {
+      "comment" : "The section header for other information in the student info page",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Other"
           }
         }
       }


### PR DESCRIPTION
- Changed some SF Symbols used
- Listed phone numbers for emergency contacts and doctors instead of hiding them in a context menu
- Errors during loading are now displayed
- Fixed a typo
- Reformatted code to be more readable and less crowded (mostly formatted localized strings onto several lines)